### PR TITLE
Fix links to supplementary material

### DIFF
--- a/_posts/2010-03-31-adams10a.md
+++ b/_posts/2010-03-31-adams10a.md
@@ -12,7 +12,7 @@ abstract: Deep belief networks are a powerful way to model complex probability  
   use Markov chain Monte Carlo for inference in   this model and explore the structures
   learned on image data.
 pdf: http://proceedings.mlr.press/v9/adams10a/adams10a.pdf
-supplementary: http://proceedings.mlr.press/v9/adams10a///jmlr.org/proceedings/papers/v9/adams10a/adams10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/adams10a/adams10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: adams10a

--- a/_posts/2010-03-31-dimitrakakis10a.md
+++ b/_posts/2010-03-31-dimitrakakis10a.md
@@ -10,7 +10,7 @@ abstract: We present a simple, effective generalisation of variable order   Mark
   experts.  Experimental results show that the   predictive model exhibits consistently
   good performance in a variety   of domains.
 pdf: http://proceedings.mlr.press/v9/dimitrakakis10a/dimitrakakis10a.pdf
-supplementary: http://proceedings.mlr.press/v9/dimitrakakis10a///jmlr.org/proceedings/papers/v9/dimitrakakis10a/dimitrakakis10aSupple.tgz
+supplementary: http://proceedings.mlr.press/v9/dimitrakakis10a/dimitrakakis10aSupple.tgz
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: dimitrakakis10a

--- a/_posts/2010-03-31-kakade10a.md
+++ b/_posts/2010-03-31-kakade10a.md
@@ -8,7 +8,7 @@ abstract: The versatility of exponential families, along with their attendant co
   we show how this property can be used to analyze generic exponential families under
   L1 regularization.
 pdf: http://proceedings.mlr.press/v9/kakade10a/kakade10a.pdf
-supplementary: http://proceedings.mlr.press/v9/kakade10a///jmlr.org/proceedings/papers/v9/kakade10a/kakade10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/kakade10a/kakade10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: kakade10a

--- a/_posts/2010-03-31-kloft10a.md
+++ b/_posts/2010-03-31-kloft10a.md
@@ -10,7 +10,7 @@ abstract: 'Security analysis of learning algorithms is gaining increasing import
   analysis of its efficiency and constraints. Experimental evaluation carried out
   on real HTTP and exploit traces confirms the tightness of our theoretical bounds.'
 pdf: http://proceedings.mlr.press/v9/kloft10a/kloft10a.pdf
-supplementary: http://proceedings.mlr.press/v9/kloft10a///jmlr.org/proceedings/papers/v9/kloft10a/kloft10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/kloft10a/kloft10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: kloft10a

--- a/_posts/2010-03-31-kolar10a.md
+++ b/_posts/2010-03-31-kolar10a.md
@@ -16,7 +16,7 @@ abstract: We propose a novel application of the Simultaneous Orthogonal Matching
   The finite sample performance of the S-OMP has been demonstrated on extensive simulation
   studies.
 pdf: http://proceedings.mlr.press/v9/kolar10a/kolar10a.pdf
-supplementary: http://proceedings.mlr.press/v9/kolar10a///jmlr.org/proceedings/papers/v9/kolar10a/kolar10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/kolar10a/kolar10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: kolar10a

--- a/_posts/2010-03-31-lever10a.md
+++ b/_posts/2010-03-31-lever10a.md
@@ -6,7 +6,7 @@ abstract: We relate function class complexity to structure in the function domai
   which is particularly effective in semi-supervised learning. In particular we quantify
   the complexity of function classes defined over a graph in terms of the graph structure.
 pdf: http://proceedings.mlr.press/v9/lever10a/lever10a.pdf
-supplementary: http://proceedings.mlr.press/v9/lever10a///jmlr.org/proceedings/papers/v9/lever10a/lever10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/lever10a/lever10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: lever10a

--- a/_posts/2010-03-31-lu10a.md
+++ b/_posts/2010-03-31-lu10a.md
@@ -20,7 +20,7 @@ abstract: We study contextual multi-armed bandit problems where the context come
   of the query spaces and the ad space respectively. For finite spaces or convex bounded
   subsets of Euclidean spaces, this gives an almost matching upper and lower bound.
 pdf: http://proceedings.mlr.press/v9/lu10a/lu10a.pdf
-supplementary: http://proceedings.mlr.press/v9/lu10a///jmlr.org/proceedings/papers/v9/lu10a/lu10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/lu10a/lu10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: lu10a

--- a/_posts/2010-03-31-murray10a.md
+++ b/_posts/2010-03-31-murray10a.md
@@ -9,7 +9,7 @@ abstract: 'Many probabilistic models introduce strong dependencies between varia
   for use while model building, removing the need to spend time deriving and tuning
   updates for more complex algorithms.'
 pdf: http://proceedings.mlr.press/v9/murray10a/murray10a.pdf
-supplementary: http://proceedings.mlr.press/v9/murray10a///jmlr.org/proceedings/papers/v9/murray10a/murray10aSupple.tgz
+supplementary: http://proceedings.mlr.press/v9/murray10a/murray10aSupple.tgz
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: murray10a

--- a/_posts/2010-03-31-ross10a.md
+++ b/_posts/2010-03-31-ross10a.md
@@ -14,7 +14,7 @@ abstract: 'Imitation Learning, while applied successfully on many large real-wor
   Tux Kart) and 2) Mario Bros.; given input images from the games and corresponding
   actions taken by a human expert and near-optimal planner respectively.'
 pdf: http://proceedings.mlr.press/v9/ross10a/ross10a.pdf
-supplementary: http://proceedings.mlr.press/v9/ross10a///jmlr.org/proceedings/papers/v9/ross10a/ross10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/ross10a/ross10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: ross10a

--- a/_posts/2010-03-31-saal10a.md
+++ b/_posts/2010-03-31-saal10a.md
@@ -11,7 +11,7 @@ abstract: 'We consider the problem of tactile discrimination, with the goal of e
   a real robotic hand-arm system that estimates the viscosity of liquids from tactile
   feedback data.'
 pdf: http://proceedings.mlr.press/v9/saal10a/saal10a.pdf
-supplementary: http://proceedings.mlr.press/v9/saal10a///jmlr.org/proceedings/papers/v9/saal10a/saal10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/saal10a/saal10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: saal10a

--- a/_posts/2010-03-31-song10a.md
+++ b/_posts/2010-03-31-song10a.md
@@ -11,7 +11,7 @@ abstract: We introduce a nonparametric representation for graphical model on tre
   state-of-the-art techniques  in a cross-lingual document retrieval task and  a camera
   rotation estimation problem.
 pdf: http://proceedings.mlr.press/v9/song10a/song10a.pdf
-supplementary: http://proceedings.mlr.press/v9/song10a///jmlr.org/proceedings/papers/v9/song10a/song10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/song10a/song10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: song10a

--- a/_posts/2010-03-31-wallach10a.md
+++ b/_posts/2010-03-31-wallach10a.md
@@ -13,7 +13,7 @@ abstract: 'Prior distributions play a crucial role in Bayesian approaches to clu
   performance on a real document clustering task, demonstrating the practical advantage
   of the uniform process despite its lack of exchangeability over orderings.'
 pdf: http://proceedings.mlr.press/v9/wallach10a/wallach10a.pdf
-supplementary: http://proceedings.mlr.press/v9/wallach10a///jmlr.org/proceedings/papers/v9/wallach10a/wallach10aSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/wallach10a/wallach10aSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: wallach10a

--- a/_posts/2010-03-31-zhang10c.md
+++ b/_posts/2010-03-31-zhang10c.md
@@ -19,7 +19,7 @@ abstract: Multi-task learning seeks to improve the generalization performance of
   of MTGTP, such as its asymptotic analysis and learning curve. Comparative experimental
   studies on two common multi-task learning applications show very promising results.
 pdf: http://proceedings.mlr.press/v9/zhang10c/zhang10c.pdf
-supplementary: http://proceedings.mlr.press/v9/zhang10c///jmlr.org/proceedings/papers/v9/zhang10c/zhang10cSupple.pdf
+supplementary: http://proceedings.mlr.press/v9/zhang10c/zhang10cSupple.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: zhang10c


### PR DESCRIPTION
The links to the supplementary material are broken in these proceedings, and this pull request proposes a fix.